### PR TITLE
fix!reorder package export conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
         "import": "./dist/index.js",
         "require": "./bundle/jinter.cjs"
       },
-      "default": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Description
In the `package.json`, the default export condition is not the last, and as a result, bundling this library using webpack when targeting `web` causes the error: `Module not found: Error: Default condition should be last one`. This can be resolved by moving the `default` condition to the end of the package exports.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

##  Minimal example of the problem
_before_
[link to gist 
<img src="https://user-images.githubusercontent.com/106682128/241584983-6de05366-c78f-4382-ba2b-e0440d85508e.png" width="500" />](https://gist.github.com/MarmadileManteater/69f92e34f2c8b56b52b8960a32c152bd)
_after_
[link to gist 
<img src="https://user-images.githubusercontent.com/106682128/241585054-db69f572-5809-43db-b7e1-cbd76ace4fdc.png" width="500" />](https://gist.github.com/MarmadileManteater/8828e59c6c31f903ba41cf0f19acb778)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings