### PR TITLE
feat: Add support for template literals

### DIFF
--- a/src/nodes/TemplateLiteral.ts
+++ b/src/nodes/TemplateLiteral.ts
@@ -1,0 +1,36 @@
+import type ESTree from 'estree';
+import BaseJSNode from './BaseJSNode.js';
+
+export default class TemplateLiteral extends BaseJSNode<ESTree.TemplateLiteral> {
+  public run() {
+    let result: string = "";
+
+    for (let i = 0; i < this.node.quasis.length; ++i) {
+      let quasi = this.node.quasis[i];
+
+      if (quasi.type === 'TemplateElement') {
+        if (quasi.value.cooked === null) {
+          throw new Error(`Invalid template literal: ${quasi.value.raw}`);
+        }
+
+        if (quasi.value.cooked !== undefined) {
+          result += quasi.value.cooked;
+        }
+
+        if (!quasi.tail) {
+          let expr = this.node.expressions[i];
+          if (expr !== undefined) {
+            // This will automatically stringify the node's return value, since result is a string.
+            result += this.visitor.visitNode(expr);
+          } else {
+            throw new Error(`Expected expression after: ${quasi.value}`);
+          }
+        }
+      } else {
+        throw new Error(`Unhandled quasi type: ${quasi.type}`);
+      }
+    }
+
+    return result;
+  }
+}

--- a/src/nodes/index.ts
+++ b/src/nodes/index.ts
@@ -25,6 +25,7 @@ export { default as ReturnStatement } from './ReturnStatement.js';
 export { default as SequenceExpression } from './SequenceExpression.js';
 export { default as SwitchCase } from './SwitchCase.js';
 export { default as SwitchStatement } from './SwitchStatement.js';
+export { default as TemplateLiteral } from './TemplateLiteral.js';
 export { default as ThisExpression } from './ThisExpression.js';
 export { default as ThrowStatement } from './ThrowStatement.js';
 export { default as TryStatement } from './TryStatement.js';

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -608,5 +608,18 @@ describe('Jinter Tests', () => {
 
       expect(jinter.scope.get('result')).toBeTruthy();
     });
+
+    it('should support template literals', () => {
+      const code = `
+        let a = \`world\`;
+        let b = 1234;
+        const result = \`hello \${a}\${a}, \\u{55} \${b * 2}! \${'test'}\`;
+      `;
+
+      const jinter = new Jinter();
+      jinter.evaluate(code)
+
+      expect(jinter.scope.get('result')).toBe('hello worldworld, U 2468! test');
+    });
   });
 });


### PR DESCRIPTION
I added support for template literals. Here's the working test case:
```js
it('should support template literals', () => {
  const code = `
    let a = \`world\`;
    let b = 1234;
    const result = \`hello \${a}\${a}, \\u{55} \${b * 2}! \${'test'}\`;
  `;

  const jinter = new Jinter();
  jinter.evaluate(code)

  expect(jinter.scope.get('result')).toBe('hello worldworld, U 2468! test');
});
```
