### PR TITLE
fix(statements): Use prefixed strings to avoid internal conflicts

### DIFF
--- a/src/nodes/BlockStatement.ts
+++ b/src/nodes/BlockStatement.ts
@@ -9,7 +9,7 @@ export default class BlockStatement extends BaseJSNode<ESTree.BlockStatement> {
       if (stmt.type === 'ReturnStatement')
         return result;
 
-      if (result === 'break' || result === 'continue')
+      if (result === '$jintr_break_' || result === '$jintr_continue_')
         return result;
 
       if (

--- a/src/nodes/BreakStatement.ts
+++ b/src/nodes/BreakStatement.ts
@@ -4,6 +4,6 @@ import BaseJSNode from './BaseJSNode.js';
 export default class BreakStatement extends BaseJSNode<ESTree.BreakStatement> {
   public run(): any {
     // @TODO: Parse label
-    return 'break';
+    return '$jintr_break_';
   }
 }

--- a/src/nodes/ContinueStatement.ts
+++ b/src/nodes/ContinueStatement.ts
@@ -3,6 +3,6 @@ import BaseJSNode from './BaseJSNode.js';
 
 export default class ContinueStatement extends BaseJSNode<ESTree.ContinueStatement> {
   public run(): any {
-    return 'continue';
+    return '$jintr_continue_';
   }
 }

--- a/src/nodes/ForOfStatement.ts
+++ b/src/nodes/ForOfStatement.ts
@@ -20,11 +20,11 @@ export default class ForOfStatement extends BaseJSNode<ESTree.ForOfStatement> {
 
       const body = this.visitor.visitNode(this.node.body);
 
-      if (body === 'break') {
+      if (body === '$jintr_break_') {
         break;
       }
 
-      if (body === 'continue') {
+      if (body === '$jintr_continue_') {
         continue;
       }
 

--- a/src/nodes/ForStatement.ts
+++ b/src/nodes/ForStatement.ts
@@ -22,11 +22,11 @@ export default class ForStatement extends BaseJSNode<ESTree.ForStatement> {
 
       const body = this.visitor.visitNode(this.node.body);
 
-      if (body === 'continue') {
+      if (body === '$jintr_continue_') {
         continue;
       }
 
-      if (body === 'break') {
+      if (body === '$jintr_break_') {
         break;
       }
 

--- a/src/nodes/SwitchStatement.ts
+++ b/src/nodes/SwitchStatement.ts
@@ -16,12 +16,12 @@ export default class SwitchStatement extends BaseJSNode<ESTree.SwitchStatement> 
         const result = this.visitor.visitNode(_case);
 
         // If it's a break then stop here.
-        if (result === 'break') {
+        if (result === '$jintr_break_') {
           break;
         }
 
         // Switch statements do not support continue, but it can be used when inside a while/for loop.
-        if (result === 'continue') {
+        if (result === '$jintr_continue_') {
           return result;
         }
 

--- a/src/nodes/WhileStatement.ts
+++ b/src/nodes/WhileStatement.ts
@@ -6,10 +6,10 @@ export default class WhileStatement extends BaseJSNode<ESTree.WhileStatement> {
     while (this.visitor.visitNode(this.node.test)) {
       const body = this.visitor.visitNode(this.node.body);
 
-      if (body === 'break')
+      if (body === '$jintr_break_')
         break;
 
-      if (body === 'continue')
+      if (body === '$jintr_continue_')
         continue;
 
       if (body)


### PR DESCRIPTION
This fixes an issue where a conflic with reserved keywords would happen inside the interpreter if a string being evaluated was 'break' or 'continue'.

Related issues:
https://github.com/LuanRT/YouTube.js/issues/905
https://github.com/FreeTubeApp/FreeTube/issues/6845
https://github.com/iv-org/invidious-companion/issues/50
https://github.com/FreeTubeApp/FreeTube/issues/6701
https://github.com/imputnet/cobalt/issues/1123

### Example:
```js
var arr = ['a', 'break', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l'];
arr[0] = arr;

function mod(I, u) {
    if (I.length != 0) {
        u = (u % I.length + I.length) % I.length;
        var test = I[0];  // Circular reference.
        console.log('Array ref:', test);
        const breakString = I[u];
        console.log({
            iVal: I[u],
            u: I[0]
        })
        // The interpreter will halt here and jump to the 
        // end of the function.
        // So I[u] = test is never executed.
        I[0] = breakString;
        console.log({
            iVal: I[0]
        })
        I[u] = test;
        console.log({
            iVal: I[u]
        });
    }
}

mod(arr, 1);
```

Expected output:
```bash
Array ref: <ref *1> [
  [Circular *1],
  'break',
  'c',
  'd',
  'e',
  'f',
  'g',
  'h',
  'i',
  'j',
  'k',
  'l'
]
{
  iVal: 'break',
  u: <ref *1> [
    [Circular *1],
    'break',
    'c',
    'd',
    'e',
    'f',
    'g',
    'h',
    'i',
    'j',
    'k',
    'l'
  ]
}
{ iVal: 'break' }
{
  iVal: <ref *1> [
    'break',
    [Circular *1],
    'c',
    'd',
    'e',
    'f',
    'g',
    'h',
    'i',
    'j',
    'k',
    'l'
  ]
}
```

Current output:
```bash
Array ref: <ref *1> [
  [Circular *1], 'break',
  'c',           'd',
  'e',           'f',
  'g',           'h',
  'i',           'j',
  'k',           'l'
]
{
  iVal: 'break',
  u: <ref *1> [
    [Circular *1], 'break',
    'c',           'd',
    'e',           'f',
    'g',           'h',
    'i',           'j',
    'k',           'l'
  ]
}
```